### PR TITLE
Fix: Vercel.json file headers source

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
 
         {
     
-          "source": "/(.*)",
+          "source": "/api/(.*)",
     
           "headers": [
     


### PR DESCRIPTION
In order to fix the CORS issue with the vercel deployment, the vercel config was modified.